### PR TITLE
Resolve sepolicy compatibility

### DIFF
--- a/sepolicy/device.te
+++ b/sepolicy/device.te
@@ -1,1 +1,0 @@
-type baseband_log_device, dev_type;

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -1,6 +1,2 @@
-# Devices
-/dev/ttyACM0                      u:object_r:radio_device:s0
-/dev/ttyACM1                      u:object_r:baseband_log_device:s0
-
 # Sysfs files
 /sys/devices/platform/tegra-i2c.2/i2c-2/2-0028/sensor_onoff  u:object_r:sysfs_proximity_sensor:s0

--- a/sepolicy/radio.te
+++ b/sepolicy/radio.te
@@ -1,4 +1,0 @@
-userdebug_or_eng(`
-  unix_socket_connect(radio, rild_debug, rild)
-  allow radio baseband_log_device:chr_file rw_file_perms;
-')


### PR DESCRIPTION
Remove and edit sepolicy files to build with aaopt's grouper tree rather than lineage's.

No idea if this will be bootable or not, but it allows me to build, so I have hope.